### PR TITLE
Fix menu mnemonic case sensitivity issue

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -11,7 +11,7 @@
         [
           {
             "caption": "Git GUI Clients",
-            "mnemonic": "g",
+            "mnemonic": "G",
             "children":
             [              
               {


### PR DESCRIPTION
The previous menu mnemonic was 'g' but should be 'G' to match the label in
the menu. This commit fixes that.